### PR TITLE
Excluded api-campaign

### DIFF
--- a/sb1-scope.json
+++ b/sb1-scope.json
@@ -155,6 +155,12 @@
         },
         {
           "enabled": true,
+          "file": "\\/common\\/marketing\\/campaign\\/*",
+          "host": "^.*\\.sparebank1\\.no$",
+          "protocol": "any"
+        },
+        {
+          "enabled": true,
           "file": "\\/*\\/nettbank-privat\\/sparing\\/rest\\/aksjetjeneste*",
           "host": "^.*\\.sparebank1\\.no$",
           "protocol": "any"


### PR DESCRIPTION
Excluded all calls on api-campaign, because the generated data on that API is critical to the banks businesses.