### PR TITLE
Star sparebank1 no

### DIFF
--- a/sb1-scope.json
+++ b/sb1-scope.json
@@ -230,7 +230,13 @@
           "file": "\\/statistikk.*",
           "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
-        }
+        },
+        {
+          "enabled": true,
+          "file": "\\/sb1-dialoghub\\/rest\\/.*\\/frontend\\/operator-connection.*",
+          "host": "www\\.sparebank1\\.no$",
+          "protocol": "any"
+        },
       ],
       "include": [
         {

--- a/sb1-scope.json
+++ b/sb1-scope.json
@@ -5,215 +5,251 @@
       "exclude": [
         {
           "enabled": true,
-          "file": "\\/api\\/personal\\/banking\\/accounts\\/securitydeposit\\/process*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/api\\/personal\\/banking\\/accounts\\/securitydeposit\\/process.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
           "file": "\\/api\\/personal\\/banking\\/pension\\/agreements\\/portal",
-          "host": "^.*\\.sparebank1\\.no$",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/api\\/personal\\/banking\\/credit\\/applications*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/api\\/personal\\/banking\\/credit\\/applications.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/api\\/personal\\/banking\\/credit\\/accounts\\/*\\/signing-orders",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/api\\/personal\\/banking\\/credit\\/accounts\\/.*\\/signing-orders",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/api\\/personal\\/banking\\/credit\\/refinancing\\/applications*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/api\\/personal\\/banking\\/credit\\/refinancing\\/applications.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-           "file": "\\/api\\/personal\\/banking\\/membership\\/coop*",
-           "host": "^.*\\.sparebank1\\.no$",
+           "file": "\\/api\\/personal\\/banking\\/membership\\/coop.*",
+           "host": "www\\.sparebank1\\.no$",
            "protocol": "any"
         },
         {
           "enabled": true,
-           "file": "\\/api\\/personal\\/banking\\/studentloan*",
-           "host": "^.*\\.sparebank1\\.no$",
+           "file": "\\/api\\/personal\\/banking\\/studentloan.*",
+           "host": "www\\.sparebank1\\.no$",
            "protocol": "any"
         },
         {
           "enabled": true,
-           "file": "\\/api\\/personal\\/banking\\/credit\\/unsecured-debt*",
-           "host": "^.*\\.sparebank1\\.no$",
+           "file": "\\/api\\/personal\\/banking\\/credit\\/unsecured-debt.*",
+           "host": "www\\.sparebank1\\.no$",
            "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/pm-boliglan\\/rest\\/soknad\\/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/pm-boliglan\\/rest\\/soknad\\/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/sb1-nettsider-skjema\\/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/sb1-nettsider-skjema\\/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/finansiering\\/rest\\/selfservice\\/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/finansiering\\/rest\\/selfservice\\/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/finansiering\\/utsett*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/finansiering\\/utsett.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/finansiering\\/rest\\/soknad\\/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/finansiering\\/rest\\/soknad\\/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/barn\\/rest\\/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/barn\\/rest\\/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/betaling\\/rest\\/payments\\/straksbetaling",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/betaling\\/rest\\/payments\\/straksbetaling",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/betaling\\/rest\\/overforing-fra-kredittkort",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/betaling\\/rest\\/overforing-fra-kredittkort",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/innstillinger\\/rest\\/smsvarsling/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/innstillinger\\/rest\\/smsvarsling/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/kort\\/rest\\/cards\\/credit\\/application*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/kort\\/rest\\/cards\\/credit\\/application.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/kort\\/rest\\/cards\\/credit\\/limit*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/kort\\/rest\\/cards\\/credit\\/limit.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/kort\\/rest\\/cards\\/credit\\/transactions",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/kort\\/rest\\/cards\\/credit\\/transactions",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/kort\\/rest\\/cards\\/credit\\/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/kort\\/rest\\/cards\\/credit\\/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/kort\\/rest\\/cards\\/debit",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/kort\\/rest\\/cards\\/debit",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/kort\\/rest\\/cards\\/debit\\/*order*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/kort\\/rest\\/cards\\/debit\\/.*order.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/kort\\/rest\\/cards\\/*\\/fraud",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/kort\\/rest\\/cards\\/.*\\/fraud",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/kort\\/rest\\/cards\\/*\\/pin",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/kort\\/rest\\/cards\\/.*\\/pin",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/meldinger\\/rest\\/messagethreads",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/meldinger\\/rest\\/messagethreads",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/rest\\/opprettkonto*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/rest\\/opprettkonto.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/rest\\/kontoerdeling",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/rest\\/kontoerdeling",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/rest\\/kontoer\\/kontobevegelser\\/oblatbestilling",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/rest\\/kontoer\\/kontobevegelser\\/oblatbestilling",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/sparing\\/rest\\/splitt\\/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/sparing\\/rest\\/splitt\\/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/common\\/marketing\\/campaign\\/*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/common\\/marketing\\/campaign\\/.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/sparing\\/rest\\/aksjetjeneste*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/sparing\\/rest\\/aksjetjeneste.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         },
         {
           "enabled": true,
-          "file": "\\/*\\/nettbank-privat\\/utsett\\/betaling*",
-          "host": "^.*\\.sparebank1\\.no$",
+          "file": "\\/.*\\/nettbank-privat\\/utsett\\/betaling.*",
+          "host": "www\\.sparebank1\\.no$",
+          "protocol": "any"
+        },
+        {
+          "enabled": true,
+          "file": "\\/openapi/nettsider/.*/sendmessage.*",
+          "host": "www\\.sparebank1\\.no$",
+          "protocol": "any"
+        },
+        {
+          "enabled": true,
+          "file": "\\/openapi/nettsider/.*/feedback.*",
+          "host": "www\\.sparebank1\\.no$",
+          "protocol": "any"
+        },
+        {
+          "enabled": true,
+          "file": "\\/LogServlet.*",
+          "host": "www\\.sparebank1\\.no$",
+          "protocol": "any"
+        },
+        {
+          "enabled": true,
+          "file": "\\/api\\/tracking\\/.*",
+          "host": "www\\.sparebank1\\.no$",
+          "protocol": "any"
+        },
+        {
+          "enabled": true,
+          "file": "\\/statistikk.*",
+          "host": "www\\.sparebank1\\.no$",
           "protocol": "any"
         }
       ],
       "include": [
         {
           "enabled": true,
-          "file": "\\/[a-z\\-]*\\/nettbank-privat\\/*",
+          "file": "\\/[a-z\\-]*\\/nettbank-privat\\/.*",
           "host": "^www\\.sparebank1\\.no$",
           "protocol": "https"
         },
         {
           "enabled": true,
-          "file": "\\/api\\/personal\\/*",
+          "file": "\\/api\\/personal\\/.*",
           "host": "^www\\.sparebank1\\.no$",
           "protocol": "https"
+        },
+        {
+          "enabled": true,
+          "file": ".*",
+          "host": ".*\\.sparebank1\\.no$",
+          "protocol": "any"
         }
       ]
     }


### PR DESCRIPTION
Legg til *.sparebank1.no. Også nye nødvendige unntak for www.sparebank1.no, som ikke lengre blir med implisitt av at bare */nettbank-privat/ og /api/personal er inkludert. 